### PR TITLE
old and working display driver configs for LCD display

### DIFF
--- a/drivers/99-calibration-working.conf
+++ b/drivers/99-calibration-working.conf
@@ -1,0 +1,6 @@
+Section "InputClass"
+        Identifier      "calibration"
+        MatchProduct    "ADS7846 Touchscreen"
+        Option  "Calibration"   "3936 227 268 3880"
+        Option  "SwapAxes"      "1"
+EndSection

--- a/drivers/boot-config-working.txt
+++ b/drivers/boot-config-working.txt
@@ -1,0 +1,94 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+#display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[all]
+
+[pi4]
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[all]
+hdmi_force_hotplug=1
+dtparam=i2c_arm=on
+dtparam=spi=on
+enable_uart=1
+dtoverlay=tft35a:rotate=90
+config_hdmi_boost=7
+hdmi_group=2
+#hdmi_mode=1
+hdmi_mode=87
+hdmi_cvt 480 320 60 6 0 0 0
+hdmi_drive=2

--- a/drivers/cmdline-working.txt
+++ b/drivers/cmdline-working.txt
@@ -1,0 +1,1 @@
+net.ifnames=0 dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait fbcon=map:10 fixrtc quiet splash plymouth.ignore-serial-consoles

--- a/drivers/config-old.txt
+++ b/drivers/config-old.txt
@@ -1,0 +1,66 @@
+# Please DO NOT modify this file; if you need to modify the boot config, the
+# "usercfg.txt" file is the place to include user changes. Please refer to
+# the README file for a description of the various configuration files on
+# the boot partition.
+
+# The unusual ordering below is deliberate; older firmwares (in particular the
+# version initially shipped with bionic) don't understand the conditional
+# [sections] below and simply ignore them. The Pi4 doesn't boot at all with
+# firmwares this old so it's safe to place at the top. Of the Pi2 and Pi3, the
+# Pi3 uboot happens to work happily on the Pi2, so it needs to go at the bottom
+# to support old firmwares.
+
+[pi4]
+kernel=uboot_rpi_4.bin
+dtoverlay=vc4-fkms-v3d
+max_framebuffers=2
+
+[pi2]
+kernel=uboot_rpi_2.bin
+
+[pi3]
+kernel=uboot_rpi_3.bin
+
+[all]
+arm_64bit=1
+device_tree_address=0x03000000
+
+# The following settings are "defaults" expected to be overridden by the
+# included configuration. The only reason they are included is, again, to
+# support old firmwares which don't understand the "include" command.
+
+enable_uart=1
+cmdline=cmdline.txt
+
+include syscfg.txt
+include usercfg.txt
+
+disable_overscan=1
+#dtoverlay=vc4-fkms-v3d
+hdmi_drive=2
+hdmi_force_hotplug=1
+dtparam=i2c_arm=on
+dtparam=spi=on
+enable_uart=1
+dtoverlay=tft35a:rotate=90
+
+
+dtparam=audio=on
+
+display_rotate=1 
+dtoverlay=dpi18
+overscan_left=0
+overscan_right=0
+overscan_top=1
+overscan_bottom=1
+framebuffer_width=480
+framebuffer_height=320
+enable_dpi_lcd=1
+display_default_lcd=1
+dpi_group=2
+dpi_mode=87
+dpi_output_format=0x07f205
+hdmi_timings=320 0 28 18 28 480 0 2 2 4 0 0 0 60 0 32000000 6
+
+
+start_x=1

--- a/drivers/config-working.txt
+++ b/drivers/config-working.txt
@@ -1,0 +1,66 @@
+# Please DO NOT modify this file; if you need to modify the boot config, the
+# "usercfg.txt" file is the place to include user changes. Please refer to
+# the README file for a description of the various configuration files on
+# the boot partition.
+
+# The unusual ordering below is deliberate; older firmwares (in particular the
+# version initially shipped with bionic) don't understand the conditional
+# [sections] below and simply ignore them. The Pi4 doesn't boot at all with
+# firmwares this old so it's safe to place at the top. Of the Pi2 and Pi3, the
+# Pi3 uboot happens to work happily on the Pi2, so it needs to go at the bottom
+# to support old firmwares.
+
+[pi4]
+kernel=uboot_rpi_4.bin
+dtoverlay=vc4-fkms-v3d
+max_framebuffers=2
+
+[pi2]
+kernel=uboot_rpi_2.bin
+
+[pi3]
+kernel=uboot_rpi_3.bin
+
+[all]
+arm_64bit=1
+device_tree_address=0x03000000
+
+# The following settings are "defaults" expected to be overridden by the
+# included configuration. The only reason they are included is, again, to
+# support old firmwares which don't understand the "include" command.
+
+enable_uart=1
+cmdline=cmdline.txt
+
+include syscfg.txt
+include usercfg.txt
+
+disable_overscan=1
+#dtoverlay=vc4-fkms-v3d
+hdmi_drive=2
+hdmi_force_hotplug=1
+dtparam=i2c_arm=on
+dtparam=spi=on
+enable_uart=1
+dtoverlay=tft35a:rotate=90
+
+
+dtparam=audio=on
+
+display_rotate=1 
+dtoverlay=dpi18
+overscan_left=0
+overscan_right=0
+overscan_top=1
+overscan_bottom=1
+framebuffer_width=480
+framebuffer_height=320
+enable_dpi_lcd=1
+display_default_lcd=1
+dpi_group=2
+dpi_mode=87
+dpi_output_format=0x07f205
+hdmi_timings=320 0 28 18 28 480 0 2 2 4 0 0 0 60 0 32000000 6
+
+
+start_x=1

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "remote server",
+    "name": "remote-server",
     "version": "1.0.0",
-	"main": "server.js",
+    "main": "server.js",
     "scripts": {
         "start": "node server.js",
-		"test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1"
     },
-	"author": "Matthew J Kemp",
-	"license": "",
+    "author": "Matthew J Kemp",
+    "license": "",
     "description": "Remote web server for Open Shooter",
     "dependencies": {
         "express": "^4.17.1"


### PR DESCRIPTION
Added:
working /etc/X11/xorg.conf.d/99-calibration.conf
working /boot/firmware/cmdline.txt
working /boot/firmware/config.txt
working boot/config.txt      
old /boot/firmware/config.txt
For Ubuntu 20.04 with a Hosyond 3.5 Inch 480x320 Touch Screen TFT LCD SPI Display

* additional *
fixed the remote server package.json name
